### PR TITLE
fix: 単体テストのMongoDB Driverバージョン不整合を修正

### DIFF
--- a/database/connection_test.go
+++ b/database/connection_test.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -69,7 +68,7 @@ func TestNewConnection_Environment(t *testing.T) {
 func TestDatabase_Close(t *testing.T) {
 	// Test closing a nil client (should not panic)
 	db := &Database{}
-	
+
 	err := db.Close()
 	if err == nil {
 		t.Error("Expected error when closing database with nil client")
@@ -79,12 +78,12 @@ func TestDatabase_Close(t *testing.T) {
 func TestNewConnection_Timeout(t *testing.T) {
 	// Test that the function uses proper timeout
 	start := time.Now()
-	
+
 	// This will timeout since we don't have a MongoDB instance
 	_, err := NewConnection()
-	
+
 	elapsed := time.Since(start)
-	
+
 	if err == nil {
 		t.Error("Expected connection to fail without MongoDB instance")
 	}
@@ -97,14 +96,10 @@ func TestNewConnection_Timeout(t *testing.T) {
 
 func TestNewConnection_ContextHandling(t *testing.T) {
 	// Test that context cancellation works properly
-	
-	// Create a context that will be cancelled immediately
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-	
+
 	// Since NewConnection creates its own context, we can't directly test context cancellation
 	// but we can ensure the function handles context properly by checking it doesn't hang indefinitely
-	
+
 	done := make(chan bool, 1)
 	go func() {
 		_, err := NewConnection()
@@ -113,7 +108,7 @@ func TestNewConnection_ContextHandling(t *testing.T) {
 		}
 		done <- true
 	}()
-	
+
 	select {
 	case <-done:
 		// Function completed, which is expected
@@ -126,10 +121,10 @@ func TestNewConnection_DefaultValues(t *testing.T) {
 	// Clear environment variables to test defaults
 	originalURI := os.Getenv("MONGODB_URI")
 	originalDBName := os.Getenv("DATABASE_NAME")
-	
+
 	os.Unsetenv("MONGODB_URI")
 	os.Unsetenv("DATABASE_NAME")
-	
+
 	defer func() {
 		// Restore original environment variables
 		if originalURI != "" {
@@ -143,7 +138,7 @@ func TestNewConnection_DefaultValues(t *testing.T) {
 			os.Unsetenv("DATABASE_NAME")
 		}
 	}()
-	
+
 	// The function should use default values when env vars are not set
 	// We can't test the actual connection, but we can verify the function
 	// attempts to use the default values by checking the error message
@@ -151,7 +146,7 @@ func TestNewConnection_DefaultValues(t *testing.T) {
 	if err == nil {
 		t.Error("Expected connection to fail without MongoDB instance")
 	}
-	
+
 	// The error should indicate it tried to connect to localhost:27017 (default)
 	if err != nil && err.Error() == "" {
 		t.Error("Expected non-empty error message")

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -15,7 +15,7 @@ import (
 	"go-mongodb-test/models"
 
 	"github.com/labstack/echo/v4"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // Mock UserService for testing
@@ -95,7 +95,7 @@ func TestUserHandler_CreateUser_Success(t *testing.T) {
 	mockService := &mockUserService{
 		createUserFunc: func(ctx context.Context, req *models.CreateUserRequest) (*models.User, error) {
 			return &models.User{
-				ID:        primitive.NewObjectID(),
+				ID:        bson.NewObjectID(),
 				UserID:    req.UserID,
 				Email:     req.Email,
 				CreatedAt: time.Now(),
@@ -213,7 +213,7 @@ func TestUserHandler_CreateUser_MissingFields(t *testing.T) {
 }
 
 func TestUserHandler_GetUser_Success(t *testing.T) {
-	userID := primitive.NewObjectID()
+	userID := bson.NewObjectID()
 	mockService := &mockUserService{
 		getUserByIDFunc: func(ctx context.Context, id string) (*models.User, error) {
 			return &models.User{
@@ -255,7 +255,7 @@ func TestUserHandler_GetUser_NotFound(t *testing.T) {
 	handler := NewUserHandler(mockService)
 	e := echo.New()
 
-	userID := primitive.NewObjectID()
+	userID := bson.NewObjectID()
 	req := httptest.NewRequest(http.MethodGet, "/users/"+userID.Hex(), nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -276,7 +276,7 @@ func TestUserHandler_GetUserByUserID_Success(t *testing.T) {
 	mockService := &mockUserService{
 		getUserByUserIDFunc: func(ctx context.Context, userID string) (*models.User, error) {
 			return &models.User{
-				ID:        primitive.NewObjectID(),
+				ID:        bson.NewObjectID(),
 				UserID:    userID,
 				Email:     "test@example.com",
 				CreatedAt: time.Now(),
@@ -324,14 +324,14 @@ func TestUserHandler_GetUserByUserID_MissingParam(t *testing.T) {
 func TestUserHandler_ListUsers_Success(t *testing.T) {
 	users := []*models.User{
 		{
-			ID:        primitive.NewObjectID(),
+			ID:        bson.NewObjectID(),
 			UserID:    "user1",
 			Email:     "user1@example.com",
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
 		{
-			ID:        primitive.NewObjectID(),
+			ID:        bson.NewObjectID(),
 			UserID:    "user2",
 			Email:     "user2@example.com",
 			CreatedAt: time.Now(),
@@ -381,7 +381,7 @@ func TestUserHandler_DeleteUser_Success(t *testing.T) {
 	handler := NewUserHandler(mockService)
 	e := echo.New()
 
-	userID := primitive.NewObjectID()
+	userID := bson.NewObjectID()
 	req := httptest.NewRequest(http.MethodDelete, "/users/"+userID.Hex(), nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -408,7 +408,7 @@ func TestUserHandler_DeleteUser_Success(t *testing.T) {
 }
 
 func TestUserHandler_UpdateUser_Success(t *testing.T) {
-	userID := primitive.NewObjectID()
+	userID := bson.NewObjectID()
 	updatedUser := &models.User{
 		ID:        userID,
 		UserID:    "updateduser",

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -154,7 +154,7 @@ func TestUpdateUserRequest_FieldUpdates(t *testing.T) {
 }
 
 func TestUser_StructFields(t *testing.T) {
-	id := primitive.NewObjectID()
+	id := bson.NewObjectID()
 	userID := "test123"
 	email := "test@example.com"
 	password := "hashedpassword"

--- a/services/user_service_test.go
+++ b/services/user_service_test.go
@@ -3,14 +3,14 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"go-mongodb-test/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // Mock Collection for testing
@@ -129,7 +129,7 @@ func TestUserService_ObjectIDValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := primitive.ObjectIDFromHex(tt.id)
+			_, err := bson.ObjectIDFromHex(tt.id)
 			
 			if tt.isValid && err != nil {
 				t.Errorf("Expected valid ObjectID for %s, got error: %v", tt.id, err)
@@ -237,7 +237,7 @@ func TestUserService_BSONFilterGeneration(t *testing.T) {
 	// Test BSON filter generation for different query types
 	
 	// Test ObjectID filter
-	objectID := primitive.NewObjectID()
+	objectID := bson.NewObjectID()
 	idFilter := bson.M{"_id": objectID}
 	
 	if idFilter["_id"] != objectID {


### PR DESCRIPTION
Fixes #10

## 概要
単体テストのMongoDB Driverバージョン不整合を修正しました。

## 修正内容
- MongoDB driver v1からv2に更新
- primitive.ObjectID/NewObjectID()をbson.ObjectID/NewObjectID()に変更
- services/user_service_test.goにfmtインポートを追加

## 対象ファイル
- services/user_service_test.go
- handlers/user_handler_test.go
- models/user_test.go

Generated with [Claude Code](https://claude.ai/code)